### PR TITLE
fix particle_color_frag.wgsl

### DIFF
--- a/src/particles_2d/particle_color_frag.wgsl
+++ b/src/particles_2d/particle_color_frag.wgsl
@@ -4,6 +4,5 @@
 
 @fragment
 fn fragment(in: VertexOutput) -> @location(0) vec4<f32> {
-    //return in.color * color;
-	return vec4(1.);
+	return in.color * color;
 }


### PR DESCRIPTION
fixes returning always white, not mater the particle effect settings for color over time.

fixes #6 