### PR TITLE
Attractor Support

### DIFF
--- a/crates/enoki2d/src/attractor.rs
+++ b/crates/enoki2d/src/attractor.rs
@@ -1,6 +1,0 @@
-use bevy::prelude::Component;
-
-#[derive(Component)]
-pub struct ParticleAttractor {
-    strength: f32,
-}

--- a/crates/enoki2d/src/attractor.rs
+++ b/crates/enoki2d/src/attractor.rs
@@ -1,0 +1,6 @@
+use bevy::prelude::Component;
+
+#[derive(Component)]
+pub struct ParticleAttractor {
+    strength: f32,
+}

--- a/crates/enoki2d/src/lib.rs
+++ b/crates/enoki2d/src/lib.rs
@@ -183,6 +183,7 @@ pub enum EmissionShape {
 pub struct Attractor {
     pub position: Vec2,
     pub strength: f32,
+    pub min_distance: f32,
 }
 
 /// holds the effect asset. Changing the Asset, will

--- a/crates/enoki2d/src/lib.rs
+++ b/crates/enoki2d/src/lib.rs
@@ -19,7 +19,6 @@ use color::ColorParticle2dMaterial;
 use serde::{Deserialize, Serialize};
 use values::Rval;
 
-mod attractor;
 mod color;
 mod curve;
 mod loader;
@@ -38,7 +37,7 @@ pub mod prelude {
     pub use super::update::{OneShot, ParticleEffectInstance, ParticleSpawnerState, ParticleStore};
     pub use super::values::{Random, Rval};
     pub use super::{
-        EmissionShape, EnokiPlugin, NoAutoAabb, Particle2dEffect, ParticleEffectHandle,
+        Attractor, EmissionShape, EnokiPlugin, NoAutoAabb, Particle2dEffect, ParticleEffectHandle,
         ParticleSpawner,
     };
 }
@@ -120,7 +119,6 @@ impl Plugin for EnokiPlugin {
                 update::clone_effect,
                 update::remove_finished_spawner,
                 update::update_spawner,
-                update::apply_attractor_forces,
             ),
         );
 
@@ -181,6 +179,12 @@ pub enum EmissionShape {
     Circle(f32),
 }
 
+#[derive(Deserialize, Serialize, Clone, Debug, Reflect)]
+pub struct Attractor {
+    pub position: Vec2,
+    pub strength: f32,
+}
+
 /// holds the effect asset. Changing the Asset, will
 /// effect all spanwers using it. Instead use `ParticleEffectInstance`,
 /// which is a unique copy for each spawner,
@@ -214,6 +218,7 @@ pub struct Particle2dEffect {
     pub angular_damp: Option<Rval<f32>>,
     pub scale_curve: Option<curve::MultiCurve<f32>>,
     pub color_curve: Option<curve::MultiCurve<LinearRgba>>,
+    pub attractors: Option<Vec<Attractor>>,
 }
 
 impl Default for Particle2dEffect {
@@ -236,6 +241,7 @@ impl Default for Particle2dEffect {
             angular_damp: None,
             scale_curve: None,
             color_curve: None,
+            attractors: None,
         }
     }
 }

--- a/crates/enoki2d/src/lib.rs
+++ b/crates/enoki2d/src/lib.rs
@@ -19,6 +19,7 @@ use color::ColorParticle2dMaterial;
 use serde::{Deserialize, Serialize};
 use values::Rval;
 
+mod attractor;
 mod color;
 mod curve;
 mod loader;
@@ -119,6 +120,7 @@ impl Plugin for EnokiPlugin {
                 update::clone_effect,
                 update::remove_finished_spawner,
                 update::update_spawner,
+                update::apply_attractor_forces,
             ),
         );
 

--- a/crates/enoki2d/src/update.rs
+++ b/crates/enoki2d/src/update.rs
@@ -273,7 +273,8 @@ fn update_particle(
 
             if distance_sq > 0.0 {
                 let distance = distance_sq.sqrt();
-                let force_magnitude = attractor.strength / distance_sq.max(1.0);
+                let min_distance_sq = attractor.min_distance * attractor.min_distance;
+                let force_magnitude = attractor.strength / distance_sq.max(min_distance_sq);
                 let force_direction = to_attractor / distance;
 
                 *lin_velo += force_direction * force_magnitude * delta;

--- a/crates/enoki2d/src/update.rs
+++ b/crates/enoki2d/src/update.rs
@@ -1,5 +1,5 @@
 use super::{prelude::EmissionShape, Particle2dEffect, ParticleEffectHandle};
-use crate::values::Random;
+use crate::{attractor::ParticleAttractor, values::Random};
 use bevy::{
     prelude::*,
     render::primitives::Aabb,
@@ -287,3 +287,5 @@ pub(crate) fn calculcate_particle_bounds(
             .try_insert(Aabb::from_min_max(min.extend(0.), max.extend(0.)));
     });
 }
+
+pub(crate) fn apply_attractor_forces(attractors: Query<(&ParticleAttractor, &GlobalTransform)>) {}

--- a/crates/enoki2d_editor/src/gui.rs
+++ b/crates/enoki2d_editor/src/gui.rs
@@ -230,6 +230,74 @@ pub(crate) fn config_gui(
     });
 
     ui.separator();
+    collapsing_header("Attractors").show(ui, |ui| {
+        let mut should_clear_attractors = false;
+
+        if let Some(attractors) = effect.attractors.as_mut() {
+            let mut to_remove: Option<usize> = None;
+
+            for (i, attractor) in attractors.iter_mut().enumerate() {
+                egui::Grid::new(format!("attractor_{i}"))
+                    .spacing([4., 4.])
+                    .min_col_width(80.)
+                    .num_columns(3)
+                    .show(ui, |ui| {
+                        ui.label(format!("Attractor {}", i + 1));
+                        ui.add(
+                            egui::DragValue::new(&mut attractor.position.x)
+                                .prefix("X: ")
+                                .speed(1.0),
+                        );
+                        if ui.button("🗑").clicked() {
+                            to_remove = Some(i);
+                        }
+                        ui.end_row();
+
+                        ui.label("Position");
+                        ui.add(
+                            egui::DragValue::new(&mut attractor.position.y)
+                                .prefix("Y: ")
+                                .speed(1.0),
+                        );
+                        ui.end_row();
+
+                        ui.label("Strength");
+                        ui.add(slider(&mut attractor.strength, 0.0..=1000000.0).logarithmic(true));
+                        ui.end_row();
+                    });
+                ui.separator();
+            }
+
+            if let Some(index) = to_remove {
+                attractors.remove(index);
+            }
+
+            if attractors.is_empty() {
+                should_clear_attractors = true;
+            }
+
+            if ui.button("Add Attractor").clicked() {
+                attractors.push(Attractor {
+                    position: Vec2::new(0.0, 0.0),
+                    strength: 10000.0,
+                });
+            }
+        } else {
+            ui.label("No attractors defined");
+            if ui.button("Add First Attractor").clicked() {
+                effect.attractors = Some(vec![Attractor {
+                    position: Vec2::new(0.0, 0.0),
+                    strength: 10000.0,
+                }]);
+            }
+        }
+
+        if should_clear_attractors {
+            effect.attractors = None;
+        }
+    });
+
+    ui.separator();
     collapsing_header("Scale").show(ui, |ui| {
         if let Some(scale_curve) = effect.scale_curve.as_mut() {
             curve_field_f32(ui, scale_curve);

--- a/crates/enoki2d_editor/src/gui.rs
+++ b/crates/enoki2d_editor/src/gui.rs
@@ -243,22 +243,25 @@ pub(crate) fn config_gui(
                     .num_columns(3)
                     .show(ui, |ui| {
                         ui.label(format!("Attractor {}", i + 1));
-                        ui.add(
-                            egui::DragValue::new(&mut attractor.position.x)
-                                .prefix("X: ")
-                                .speed(1.0),
-                        );
+
                         if ui.button("🗑").clicked() {
                             to_remove = Some(i);
                         }
                         ui.end_row();
 
                         ui.label("Position");
-                        ui.add(
-                            egui::DragValue::new(&mut attractor.position.y)
-                                .prefix("Y: ")
-                                .speed(1.0),
-                        );
+                        ui.horizontal(|ui| {
+                            ui.add(
+                                egui::DragValue::new(&mut attractor.position.x)
+                                    .prefix("X: ")
+                                    .speed(1.0),
+                            );
+                            ui.add(
+                                egui::DragValue::new(&mut attractor.position.y)
+                                    .prefix("Y: ")
+                                    .speed(1.0),
+                            );
+                        });
                         ui.end_row();
 
                         ui.label("Strength");

--- a/crates/enoki2d_editor/src/gui.rs
+++ b/crates/enoki2d_editor/src/gui.rs
@@ -262,7 +262,13 @@ pub(crate) fn config_gui(
                         ui.end_row();
 
                         ui.label("Strength");
-                        ui.add(slider(&mut attractor.strength, 0.0..=1000000.0).logarithmic(true));
+                        ui.add(
+                            slider(&mut attractor.strength, 0.0..=100000000.0).logarithmic(true),
+                        );
+                        ui.end_row();
+
+                        ui.label("Min Distance");
+                        ui.add(slider(&mut attractor.min_distance, 0.1..=100.0));
                         ui.end_row();
                     });
                 ui.separator();
@@ -280,6 +286,7 @@ pub(crate) fn config_gui(
                 attractors.push(Attractor {
                     position: Vec2::new(0.0, 0.0),
                     strength: 10000.0,
+                    min_distance: 5.0,
                 });
             }
         } else {
@@ -288,6 +295,7 @@ pub(crate) fn config_gui(
                 effect.attractors = Some(vec![Attractor {
                     position: Vec2::new(0.0, 0.0),
                     strength: 10000.0,
+                    min_distance: 5.0,
                 }]);
             }
         }

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -4,9 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = {version = "0.16.0", features = [
-	"file_watcher",
-]}
+bevy = { version = "0.16.0", features = ["file_watcher"] }
 bevy_enoki = { path = "../crates/enoki2d" }
 rand = "0.8.5"
 
@@ -21,3 +19,7 @@ path = "src/dynamic.rs"
 [[bin]]
 name = "material"
 path = "src/material.rs"
+
+[[bin]]
+name = "attractor"
+path = "src/attractor.rs"

--- a/example/assets/attractor.particle.ron
+++ b/example/assets/attractor.particle.ron
@@ -1,0 +1,22 @@
+(
+    spawn_rate: 0.1,
+    spawn_amount: 10,
+    emission_shape: Circle(100.0),
+    lifetime: (1.0, 0.0),
+    direction: Some(((0, 1), 0.1)),
+    linear_speed: Some((0, 0)),
+    linear_acceleration: Some((0, 0)),
+    angular_speed: Some((0, 0)),
+    angular_acceleration: Some((0, 0)),
+    gravity_speed: Some((0, 0)),
+    gravity_direction: Some(((0, 0), 0)),
+    scale: Some((5., 0.5)),
+    linear_damp: Some((0, 0.0)),
+    angular_damp: Some((0, 0)),
+    attractors: Some([
+        (
+            position: (0.0, 0.0),
+            strength: 1000000.0,
+        ),
+    ]),
+)

--- a/example/assets/attractor.particle.ron
+++ b/example/assets/attractor.particle.ron
@@ -17,6 +17,7 @@
         (
             position: (0.0, 0.0),
             strength: 1000000.0,
+            min_distance: 5.0,
         ),
     ]),
 )

--- a/example/src/attractor.rs
+++ b/example/src/attractor.rs
@@ -1,0 +1,15 @@
+use bevy::prelude::*;
+use bevy_enoki::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(EnokiPlugin)
+        .add_systems(Startup, setup)
+        .run();
+}
+
+fn setup(mut cmds: Commands) {
+    cmds.spawn(Camera2d);
+    cmds.spawn(ParticleSpawner::default());
+}

--- a/example/src/attractor.rs
+++ b/example/src/attractor.rs
@@ -9,7 +9,12 @@ fn main() {
         .run();
 }
 
-fn setup(mut cmds: Commands) {
+fn setup(mut cmds: Commands, server: Res<AssetServer>) {
     cmds.spawn(Camera2d);
-    cmds.spawn(ParticleSpawner::default());
+
+    // Spawn particle spawner with attractors defined in the effect file
+    cmds.spawn((
+        ParticleSpawner::default(),
+        ParticleEffectHandle(server.load("attractor.particle.ron")),
+    ));
 }


### PR DESCRIPTION
# Add Attractor Support

  ## Summary
  This PR adds comprehensive attractor functionality to the bevy_enoki particle system, allowing particles to be influenced by attraction forces defined within particle effect assets.

https://github.com/user-attachments/assets/c701e0c7-57a5-4098-b91e-089c45319349


  ## Key Changes

  ### Core Functionality
  - **New Attractor System**: Particles can now be attracted to specific points with configurable strength and minimum distance
  - **Asset-Based Configuration**: Attractors are defined in `.particle.ron` files as part of the effect, making them reusable and hot-reloadable
  - **Physics Integration**: Uses inverse square law physics with minimum distance clamping to prevent "slingshot" effects

  ### Technical Implementation
  - **`Attractor` Struct**: New struct with `position`, `strength`, and `min_distance` fields
  - **Effect Integration**: Added `attractors: Option<Vec<Attractor>>` to `Particle2dEffect`
  - **Physics Calculation**: Integrated attractor forces into the existing particle update pipeline for optimal performance
  - **Minimum Distance Clamping**: Prevents particles from getting extreme velocities when passing too close to attractors

  ### Editor Support
  - **Visual Editor**: Complete UI for adding, editing, and removing attractors in the web-based editor
  - **Intuitive Controls**:
    - Position editing with X/Y drag values on the same row
    - Logarithmic strength slider (0 to 100M range)
    - Minimum distance slider (0.1 to 100 units)
    - Delete button for each attractor
  - **Dynamic Management**: Add/remove attractors with proper state cleanup

  ### Files Modified
  - `crates/enoki2d/src/lib.rs` - Added Attractor struct and effect integration
  - `crates/enoki2d/src/update.rs` - Integrated attractor physics into particle updates
  - `crates/enoki2d_editor/src/gui.rs` - Added complete editor UI for attractors
  - `example/src/attractor.rs` - Updated example to use asset-based attractors
  - `example/assets/attractor.particle.ron` - Example particle effect with attractors

  ### Example Usage
  ```ron
  attractors: Some([
      (
          position: (100.0, 50.0),
          strength: 10000.0,
          min_distance: 5.0,
      ),
  ]),
```