### PR TITLE
Relative Particle Positioning

### DIFF
--- a/crates/enoki2d/src/lib.rs
+++ b/crates/enoki2d/src/lib.rs
@@ -220,6 +220,7 @@ pub struct Particle2dEffect {
     pub scale_curve: Option<curve::MultiCurve<f32>>,
     pub color_curve: Option<curve::MultiCurve<LinearRgba>>,
     pub attractors: Option<Vec<Attractor>>,
+    pub relative_positioning: Option<bool>,
 }
 
 impl Default for Particle2dEffect {
@@ -243,6 +244,7 @@ impl Default for Particle2dEffect {
             scale_curve: None,
             color_curve: None,
             attractors: None,
+            relative_positioning: None,
         }
     }
 }

--- a/crates/enoki2d_editor/src/gui.rs
+++ b/crates/enoki2d_editor/src/gui.rs
@@ -135,6 +135,11 @@ pub(crate) fn config_gui(
         //
         slider_field(ui, "Amount", &mut effect.spawn_amount, 1..=1000000);
         slider_field(ui, "Spawn rate", &mut effect.spawn_rate, (0.01)..=120.);
+        
+        // Relative positioning checkbox
+        let mut relative_positioning = effect.relative_positioning.unwrap_or(false);
+        ui.checkbox(&mut relative_positioning, "Relative Positioning");
+        effect.relative_positioning = Some(relative_positioning);
 
         ui.label("Emission type");
 

--- a/crates/enoki2d_editor/src/gui.rs
+++ b/crates/enoki2d_editor/src/gui.rs
@@ -25,6 +25,20 @@ pub(crate) fn scene_gui(ui: &mut Ui, settings: &mut SceneSettings) {
                 egui::color_picker::Alpha::Opaque,
             );
             ui.end_row();
+            ui.checkbox(&mut settings.move_effect, "Move Effect");
+            ui.end_row();
+            ui.label("Move Radius");
+            ui.add_enabled(
+                settings.move_effect,
+                egui::Slider::new(&mut settings.move_effect_radius, 0.0..=1000.0),
+            );
+            ui.end_row();
+            ui.label("Move Speed");
+            ui.add_enabled(
+                settings.move_effect,
+                egui::Slider::new(&mut settings.move_effect_speed, 0.1..=5.0),
+            );
+            ui.end_row();
             ui.label(RichText::new("Bloom Settings").strong());
             ui.end_row();
             match &mut settings.bloom {
@@ -135,7 +149,7 @@ pub(crate) fn config_gui(
         //
         slider_field(ui, "Amount", &mut effect.spawn_amount, 1..=1000000);
         slider_field(ui, "Spawn rate", &mut effect.spawn_rate, (0.01)..=120.);
-        
+
         // Relative positioning checkbox
         let mut relative_positioning = effect.relative_positioning.unwrap_or(false);
         ui.checkbox(&mut relative_positioning, "Relative Positioning");

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -23,3 +23,7 @@ path = "src/material.rs"
 [[bin]]
 name = "attractor"
 path = "src/attractor.rs"
+
+[[bin]]
+name = "relative_position"
+path = "src/relative_position.rs"

--- a/example/assets/non-relative_pos.particle.ron
+++ b/example/assets/non-relative_pos.particle.ron
@@ -1,0 +1,30 @@
+(
+    spawn_rate: 0.1,
+    spawn_amount: 10,
+    emission_shape: Circle(100.0),
+    lifetime: (1.0, 0.0),
+    direction: Some(((0, 1), 0.1)),
+    linear_speed: Some((0, 0)),
+    linear_acceleration: Some((0, 0)),
+    angular_speed: Some((0, 0)),
+    angular_acceleration: Some((0, 0)),
+    gravity_speed: Some((0, 0)),
+    gravity_direction: Some(((0, 0), 0)),
+    scale: Some((5., 0.5)),
+    linear_damp: Some((0, 0.0)),
+    angular_damp: Some((0, 0)),
+    relative_positioning: Some(false),
+    attractors: Some([
+        (
+            position: (0.0, 0.0),
+            strength: 1000000.0,
+            min_distance: 5.0,
+        ),
+    ]),
+    color: Some(LinearRgba(
+        red: 1.0,
+        green: 0.0,
+        blue: 0.0,
+        alpha: 1.0,
+    )),
+)

--- a/example/assets/relative_pos.particle.ron
+++ b/example/assets/relative_pos.particle.ron
@@ -1,0 +1,30 @@
+(
+    spawn_rate: 0.1,
+    spawn_amount: 10,
+    emission_shape: Circle(100.0),
+    lifetime: (1.0, 0.0),
+    direction: Some(((0, 1), 0.1)),
+    linear_speed: Some((0, 0)),
+    linear_acceleration: Some((0, 0)),
+    angular_speed: Some((0, 0)),
+    angular_acceleration: Some((0, 0)),
+    gravity_speed: Some((0, 0)),
+    gravity_direction: Some(((0, 0), 0)),
+    scale: Some((5., 0.5)),
+    linear_damp: Some((0, 0.0)),
+    angular_damp: Some((0, 0)),
+    relative_positioning: Some(true),
+    attractors: Some([
+        (
+            position: (0.0, 0.0),
+            strength: 1000000.0,
+            min_distance: 5.0,
+        ),
+    ]),
+    color: Some(LinearRgba(
+        red: 0.0,
+        green: 1.0,
+        blue: 0.0,
+        alpha: 1.0,
+    )),
+)

--- a/example/src/relative_position.rs
+++ b/example/src/relative_position.rs
@@ -1,0 +1,55 @@
+use bevy::prelude::*;
+use bevy_enoki::prelude::*;
+
+const RADIUS: f32 = 200.0;
+const SPEED: f32 = 1.5;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugins(EnokiPlugin)
+        .add_systems(Startup, setup)
+        .add_systems(Update, move_spawners)
+        .run();
+}
+
+#[derive(Component)]
+struct MovingSpawner {
+    phase_offset: f32,
+}
+
+fn setup(mut cmds: Commands, server: Res<AssetServer>) {
+    cmds.spawn(Camera2d);
+
+    // Spawn particle system with relative positioning - starts on right side
+    cmds.spawn((
+        ParticleSpawner::default(),
+        ParticleEffectHandle(server.load("relative_pos.particle.ron")),
+        MovingSpawner {
+            phase_offset: 0.0, // Starts at 0 degrees (right side)
+        },
+        Transform::from_translation(Vec3::new(RADIUS, 0.0, 0.0)),
+    ));
+
+    // Spawn particle system with non-relative positioning - starts on left side
+    cmds.spawn((
+        ParticleSpawner::default(),
+        ParticleEffectHandle(server.load("non-relative_pos.particle.ron")),
+        MovingSpawner {
+            phase_offset: std::f32::consts::PI, // Starts at 180 degrees (left side)
+        },
+        Transform::from_translation(Vec3::new(-RADIUS, 0.0, 0.0)),
+    ));
+}
+
+fn move_spawners(time: Res<Time>, mut query: Query<(&mut Transform, &MovingSpawner)>) {
+    for (mut transform, moving_spawner) in query.iter_mut() {
+        // Move both spawners around the same circle, but with different phase offsets
+        let t = time.elapsed_secs();
+        let angle = t * SPEED + moving_spawner.phase_offset;
+
+        transform.translation.x = angle.cos() * RADIUS;
+        transform.translation.y = angle.sin() * RADIUS;
+        transform.translation.z = 0.0;
+    }
+}


### PR DESCRIPTION
  ## Summary
  This PR adds a new `relative_positioning` feature to the particle system that allows particles to maintain
  their position relative to their spawner entity, rather than moving independently in world space.


https://github.com/user-attachments/assets/174bdc69-de2a-48dc-be0a-c0bd7056dbf0


  ## Problem Solved
  Previously, when a particle spawner moved (e.g., as a child of another entity or when directly translated),
  existing particles would remain in their original world positions while only new particles would spawn at the
  updated spawner location. This created a "trail" effect where particles appeared disconnected from their
  moving spawner.

  ## Implementation

  ### Core Changes
  - **Added `relative_positioning: Option<bool>`** field to `Particle2dEffect` struct
  - **Enhanced spawner state tracking** by adding `previous_position: Option<Vec3>` to `ParticleSpawnerState`
  - **Modified particle update logic** to offset particle positions by spawner movement delta when relative
  positioning is enabled

  ### Editor Enhancements
  - **Added "Relative Positioning" checkbox** in the Spawner Settings panel
  - **Added "Move Effect" feature** with checkbox to preview particle behavior while moving
  - **Added configurable radius slider** (0-1000) for movement preview
  - **Added configurable speed slider** (0.1-5.0) for movement preview

  ### Example
  - **Created `relative_position.rs` example** demonstrating the feature with two spawners moving in a circular path
  - **One spawner with relative positioning enabled** - particles follow the spawner
  - **One spawner with relative positioning disabled** - particles stay behind as spawner moves

  ### Usage
  ```rust
  let effect = Particle2dEffect {
      relative_positioning: Some(true), // Enable relative positioning
      ..default()
  };
```