### PR TITLE
Add left-click panning to editor

### DIFF
--- a/crates/enoki2d_editor/src/main.rs
+++ b/crates/enoki2d_editor/src/main.rs
@@ -521,7 +521,7 @@ pub(crate) fn bottom_panel(
         .frame(frame)
         .show(ctx, |ui| {
             ui.horizontal(|ui| {
-                let text = "Log - [Mouse::Middle]: pan [Mouse::Wheel]: zoom";
+                let text = "Log - [Mouse::Middle or Mouse::Left]: pan [Mouse::Wheel]: zoom";
                 if logs.is_empty() {
                     ui.label(text);
                 } else {


### PR DESCRIPTION
Wanted to make this pull request mainly to discuss this as I couldn't find anything about it. Why not add panning via LMB to the editor? Right now you cannot pan if you don't have access to a middle mouse button and I don't think you need LMB for anything else in the scene specifically.