### PR TITLE
 Fix: Failing wasm builds

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,4 +3,4 @@
 # check status at https://developer.mozilla.org/en-US/docs/Web/API/Clipboard#browser_compatibility
 # we don't use `[build]` because of rust analyzer's build cache invalidation https://github.com/emilk/eframe_template/issues/93
 [target.wasm32-unknown-unknown]
-rustflags = ["--cfg=web_sys_unstable_apis", "--cfg=getrandom_backend=\"wasm_js\""]
+rustflags = ["--cfg=web_sys_unstable_apis"]

--- a/crates/enoki2d/.cargo/config.toml
+++ b/crates/enoki2d/.cargo/config.toml
@@ -3,4 +3,4 @@
 # check status at https://developer.mozilla.org/en-US/docs/Web/API/Clipboard#browser_compatibility
 # we don't use `[build]` because of rust analyzer's build cache invalidation https://github.com/emilk/eframe_template/issues/93
 [target.wasm32-unknown-unknown]
-rustflags = ["--cfg=web_sys_unstable_apis", "--cfg=getrandom_backend=\"wasm_js\""]
+rustflags = ["--cfg=web_sys_unstable_apis"]

--- a/crates/enoki2d/Cargo.toml
+++ b/crates/enoki2d/Cargo.toml
@@ -41,7 +41,7 @@ bevy_camera = { version = "0.17" }
 bevy_shader = { version = "0.17" }
 serde = { version = "1.0.197", features = ["derive"] }
 ron = "0.10"
-rand = { version = "0.8.5" }
+rand = "0.9.2"
 
-[target.wasm32-unknown-unknown.dependencies]
+[target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]
 getrandom = { version = "0.3", features = ["wasm_js"] }

--- a/crates/enoki2d_editor/Cargo.toml
+++ b/crates/enoki2d_editor/Cargo.toml
@@ -26,5 +26,5 @@ serde = { version = "1.0.197", features = ["derive"] }
 tracing-subscriber = "0.3.18"
 bevy_pancam = {git = "https://github.com/pindash-io/bevy_pancam.git", branch = "bevy-0.17"}
 
-[target.wasm32-unknown-unknown.dependencies]
-getrandom = { version = "0.3.3", features = ["wasm_js"] }
+[target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -4,9 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = { version = "0.17.1", features = ["file_watcher"] }
+bevy = "0.17.3"
 bevy_enoki = { path = "../crates/enoki2d" }
-rand = "0.8.5"
+rand = "0.9.2"
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+bevy = { version = "0.17.3", features = ["file_watcher"] }
+
+[target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]
+getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [[bin]]
 name = "sprites"


### PR DESCRIPTION
## Commit

This fixes #34

The main issue was that we were using rand 0.8.5.
This cause an error while building for wasm
complaining about an incorrect backend being used.
Therefore I have switched to 0.9.2 and am also
using a broader target similar to a recommendation
by bevy_rand. Rust std also uses similar syntax.

Another issue was that we were including the
file_watcher feature for wasm builds.

See: https://github.com/Bluefinger/bevy_rand?tab=readme-ov-file#usage-within-web-wasm-environments
See: https://github.com/rust-lang/rust/blob/fecb335cbad3d84ef3da39191ba094e6c726a5b4/library/std/Cargo.toml#L65

## Details

Now building for --target wasm works for all crates and examples included here. Just running this in the root works perfectly:

```
cargo build --target wasm32-unknown-unknown 
```

Before this has failed with:

```
error: the wasm*-unknown-unknown targets are not supported by default, you may need to enable the "js" feature. For more information see: https://docs.rs/getrandom/#webassembly-support
```

This also happens when building as a dependency.

## Sidenote

I have already prepared a branch to fix some other issues and outdated dependencies in `Cargo.toml`, but this would be beyond the scope of this pr. I will submit a pr for that once this has been merged though to avoid me having to fix merge conflicts.