### PR TITLE
Code smell: Fix lint warning needless borrow

### DIFF
--- a/crates/enoki2d_editor/src/file.rs
+++ b/crates/enoki2d_editor/src/file.rs
@@ -38,7 +38,7 @@ fn file_drop(
             let file_path = path_buf.to_string_lossy();
             trace!("Dropped file: {}", file_path);
             if file_path.ends_with(".particle.ron") {
-                let Ok(data) = std::fs::read(&path_buf) else {
+                let Ok(data) = std::fs::read(path_buf) else {
                     trace!("Failed to read file");
                     continue;
                 };
@@ -59,7 +59,7 @@ fn file_drop(
                     if r.is_ok() { "Success" } else { "Failed" }
                 );
             } else {
-                let Ok(data) = std::fs::read(&path_buf) else {
+                let Ok(data) = std::fs::read(path_buf) else {
                     trace!("Failed to read file");
                     continue;
                 };


### PR DESCRIPTION
## Commit

Warning:
the borrowed expression implements the required traits for further information visit https://rust-lang.github.io/rust-clippy/rust-1.92.0/index.html#needless_borrows_for_generic_args