### PR TITLE
Bevy 0.18

### DIFF
--- a/crates/enoki2d/Cargo.toml
+++ b/crates/enoki2d/Cargo.toml
@@ -16,7 +16,6 @@ dev = [
     "bevy_render/trace",
     "bevy_core_pipeline/trace",
     "bevy_render/tracing-tracy",
-    "bevy_render/tracing-tracy"
 ]
 
 [dependencies]

--- a/crates/enoki2d/Cargo.toml
+++ b/crates/enoki2d/Cargo.toml
@@ -39,7 +39,7 @@ bevy_image = { version = "0.18" }
 bevy_camera = { version = "0.18" }
 bevy_shader = { version = "0.18" }
 serde = { version = "1.0.197", features = ["derive"] }
-ron = "0.10"
+ron = "0.12"
 rand = "0.9.2"
 
 [target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]

--- a/crates/enoki2d/Cargo.toml
+++ b/crates/enoki2d/Cargo.toml
@@ -20,25 +20,25 @@ dev = [
 ]
 
 [dependencies]
-bevy_asset = { version = "0.17" }
-bevy_core_pipeline = { version = "0.17" }
-bevy_render = { version = "0.17" }
-bevy_sprite = { version = "0.17" }
-bevy_sprite_render = { version = "0.17" }
-bevy_mesh = { version = "0.17" }
-bevy_app = { version = "0.17" }
-bevy_ecs = { version = "0.17" }
-bevy_math = { version = "0.17" }
-bevy_reflect = { version = "0.17" }
-bevy_time = { version = "0.17" }
-bevy_derive = { version = "0.17" }
-bevy_transform = { version = "0.17" }
-bevy_color = { version = "0.17" }
-bevy_log = { version = "0.17" }
-bevy_tasks = { version = "0.17" }
-bevy_image = { version = "0.17" }
-bevy_camera = { version = "0.17" }
-bevy_shader = { version = "0.17" }
+bevy_asset = { version = "0.18" }
+bevy_core_pipeline = { version = "0.18" }
+bevy_render = { version = "0.18" }
+bevy_sprite = { version = "0.18" }
+bevy_sprite_render = { version = "0.18" }
+bevy_mesh = { version = "0.18" }
+bevy_app = { version = "0.18" }
+bevy_ecs = { version = "0.18" }
+bevy_math = { version = "0.18" }
+bevy_reflect = { version = "0.18" }
+bevy_time = { version = "0.18" }
+bevy_derive = { version = "0.18" }
+bevy_transform = { version = "0.18" }
+bevy_color = { version = "0.18" }
+bevy_log = { version = "0.18" }
+bevy_tasks = { version = "0.18" }
+bevy_image = { version = "0.18" }
+bevy_camera = { version = "0.18" }
+bevy_shader = { version = "0.18" }
 serde = { version = "1.0.197", features = ["derive"] }
 ron = "0.10"
 rand = "0.9.2"

--- a/crates/enoki2d/src/loader.rs
+++ b/crates/enoki2d/src/loader.rs
@@ -8,8 +8,9 @@ use bevy_ecs::{
     query::With,
     system::{Commands, Query, Res},
 };
+use bevy_reflect::TypePath;
 
-#[derive(Default)]
+#[derive(Default, TypePath)]
 pub struct ParticleEffectLoader;
 impl AssetLoader for ParticleEffectLoader {
     type Asset = Particle2dEffect;

--- a/crates/enoki2d_editor/Cargo.toml
+++ b/crates/enoki2d_editor/Cargo.toml
@@ -20,7 +20,7 @@ crossbeam = { version = "0.8.4", features = [
   "crossbeam-channel",
 ] }
 # futures-lite = "2.3.0"
-rfd = "0.15"
+rfd = "0.17"
 ron = "0.10"
 serde = { version = "1.0.197", features = ["derive"] }
 tracing-subscriber = "0.3.20"

--- a/crates/enoki2d_editor/Cargo.toml
+++ b/crates/enoki2d_editor/Cargo.toml
@@ -21,7 +21,7 @@ crossbeam = { version = "0.8.4", features = [
 ] }
 # futures-lite = "2.3.0"
 rfd = "0.17"
-ron = "0.10"
+ron = "0.12"
 serde = { version = "1.0.197", features = ["derive"] }
 tracing-subscriber = "0.3.20"
 bevy_pancam = { git = "https://github.com/blip-radar/bevy_pancam.git", branch = "bevy-0-18" }

--- a/crates/enoki2d_editor/Cargo.toml
+++ b/crates/enoki2d_editor/Cargo.toml
@@ -10,10 +10,10 @@ readme = "README.md"
 edition = "2021"
 
 [dependencies]
-bevy_egui = "0.37"
+bevy_egui = "0.39"
 anyhow = "1.0.82"
-bevy = "0.17"
-egui_plot = "0.33"
+bevy = "0.18"
+egui_plot = "0.34"
 bevy_enoki = { path = "../enoki2d" }
 crossbeam = { version = "0.8.4", features = [
   "crossbeam-deque",
@@ -23,8 +23,8 @@ crossbeam = { version = "0.8.4", features = [
 rfd = "0.15"
 ron = "0.10"
 serde = { version = "1.0.197", features = ["derive"] }
-tracing-subscriber = "0.3.18"
-bevy_pancam = {git = "https://github.com/pindash-io/bevy_pancam.git", branch = "bevy-0.17"}
+tracing-subscriber = "0.3.20"
+bevy_pancam = { git = "https://github.com/blip-radar/bevy_pancam.git", branch = "bevy-0-18" }
 
 [target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]
 getrandom = { version = "0.3", features = ["wasm_js"] }

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -4,12 +4,12 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-bevy = "0.17.3"
+bevy = "0.18"
 bevy_enoki = { path = "../crates/enoki2d" }
 rand = "0.9.2"
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-bevy = { version = "0.17.3", features = ["file_watcher"] }
+bevy = { version = "0.18", features = ["file_watcher"] }
 
 [target.'cfg(all(target_family = "wasm", any(target_os = "unknown", target_os = "none")))'.dependencies]
 getrandom = { version = "0.3", features = ["wasm_js"] }

--- a/example/src/utils.rs
+++ b/example/src/utils.rs
@@ -55,16 +55,8 @@ fn show_fps(
 }
 
 fn debug_ui() -> impl Bundle {
-    let font = TextFont {
-        font_size: 20.,
-        line_height: LineHeight::Px(24.),
-        ..default()
-    };
-    let description_font = TextFont {
-        font_size: 16.,
-        line_height: LineHeight::Px(24.),
-        ..default()
-    };
+    let font = TextFont::from_font_size(20.);
+    let description_font = TextFont::from_font_size(16.);
     let row_node = Node {
         flex_direction: FlexDirection::Row,
         justify_content: JustifyContent::SpaceAround,
@@ -91,11 +83,13 @@ fn debug_ui() -> impl Bundle {
             text_shadow,
             description_font.clone(),
             description_node.clone(),
+            LineHeight::Px(24.),
         )
     };
     let value_bundle = || {
         (
             font.clone(),
+            LineHeight::Px(24.),
             text_shadow,
             primary_color,
             TextLayout::new_with_justify(Justify::Right),
@@ -116,10 +110,10 @@ fn debug_ui() -> impl Bundle {
                 bottom: if is_top { Val::Auto } else { px(10.0) },
                 position_type: PositionType::Absolute,
                 border: UiRect::all(px(5.0)),
+                border_radius: BorderRadius::all(px(10.0)),
                 ..Default::default()
             },
             BorderColor::all(bevy::color::palettes::tailwind::NEUTRAL_600.with_alpha(0.3)),
-            BorderRadius::all(px(10.0)),
             BackgroundColor(
                 bevy::color::palettes::tailwind::NEUTRAL_900
                     // .with_alpha(0.8)


### PR DESCRIPTION
Closes #40 

- Bumped `bevy` version requirement to 0.18.
- Migrated code to be compatible with 0.18.
- Bumped `tracing-subscriber` version requirement to 0.3.20.
- Bumped `bevy_egui` version requirement to 0.39 and `egui_plot` to 0.34.
- Bumped `rfd` version requirement to 0.17.
- Bumped `ron` version requirement to 0.12.
- `bevy_pancam` git dependency now points to `blip-radar:bevy_pancam.git`.
- Removed a redundant feature flag that was enabled by the `dev` feature flag.