### PR TITLE
Fix calculated aabb for spawners

### DIFF
--- a/crates/enoki2d/src/lib.rs
+++ b/crates/enoki2d/src/lib.rs
@@ -135,7 +135,7 @@ impl Plugin for EnokiPlugin {
         app.add_systems(
             PostUpdate,
             (
-                update::calculcate_particle_bounds.in_set(VisibilitySystems::CalculateBounds),
+                update::calculate_particle_bounds.in_set(VisibilitySystems::CalculateBounds),
                 // check_visibility.in_set(VisibilitySystems::CheckVisibility),
             ),
         );

--- a/crates/enoki2d/src/update.rs
+++ b/crates/enoki2d/src/update.rs
@@ -319,7 +319,7 @@ fn update_particle(
     particle.transform.rotate_local_z(*rot_velo * delta);
 }
 
-pub(crate) fn calculcate_particle_bounds(
+pub(crate) fn calculate_particle_bounds(
     mut cmd: Commands,
     spawners: Query<(Entity, &ParticleStore, &GlobalTransform), Without<crate::NoAutoAabb>>,
 ) {

--- a/crates/enoki2d/src/update.rs
+++ b/crates/enoki2d/src/update.rs
@@ -321,9 +321,9 @@ fn update_particle(
 
 pub(crate) fn calculcate_particle_bounds(
     mut cmd: Commands,
-    spawners: Query<(Entity, &ParticleStore), Without<crate::NoAutoAabb>>,
+    spawners: Query<(Entity, &ParticleStore, &GlobalTransform), Without<crate::NoAutoAabb>>,
 ) {
-    spawners.iter().for_each(|(entity, store)| {
+    spawners.iter().for_each(|(entity, store, transform)| {
         if store.is_empty() {
             return;
         }
@@ -333,14 +333,17 @@ pub(crate) fn calculcate_particle_bounds(
             .iter()
             .enumerate()
             .filter(|(i, _)| i % accuracy == 0)
-            .fold((Vec2::ZERO, Vec2::ZERO), |mut acc, (_, particle)| {
+            .fold((Vec2::MAX, Vec2::MIN), |mut acc, (_, particle)| {
                 acc.0.x = acc.0.x.min(particle.transform.translation.x);
                 acc.0.y = acc.0.y.min(particle.transform.translation.y);
                 acc.1.x = acc.1.x.max(particle.transform.translation.x);
                 acc.1.y = acc.1.y.max(particle.transform.translation.y);
                 acc
             });
-        cmd.entity(entity)
-            .try_insert(Aabb::from_min_max(min.extend(0.), max.extend(0.)));
+
+        let mut aabb = Aabb::from_min_max(min.extend(0.), max.extend(0.));
+        aabb.center -= transform.translation().to_vec3a();
+
+        cmd.entity(entity).try_insert(aabb);
     });
 }

--- a/example/src/utils.rs
+++ b/example/src/utils.rs
@@ -15,7 +15,7 @@ pub struct ParticlesText;
 pub(crate) fn camera_and_ui_plugin(app: &mut App) {
     app.add_systems(PostStartup, spawn_ui)
         .add_plugins(bevy::diagnostic::FrameTimeDiagnosticsPlugin::default())
-        .add_systems(Update, (show_fps, move_camera));
+        .add_systems(Update, (show_fps, move_camera, toggle_aabb_gizmo));
 }
 fn spawn_ui(mut cmd: Commands) {
     cmd.spawn((
@@ -65,7 +65,7 @@ fn debug_ui() -> impl Bundle {
     };
     let description_node = Node {
         margin: UiRect::right(px(10.0)),
-        width: Val::Px(100.0),
+        width: Val::Px(150.0),
         ..Default::default()
     };
     let text_shadow = TextShadow {
@@ -148,7 +148,7 @@ fn debug_ui() -> impl Bundle {
                 frame_bundle(false),
                 children![
                     (
-                        Text(String::from("Camera Controls")),
+                        Text(String::from("Controls")),
                         font.clone(),
                         primary_color,
                         text_shadow,
@@ -171,10 +171,17 @@ fn debug_ui() -> impl Bundle {
                     (
                         row_node.clone(),
                         children![
-                            secondary_bundle("Move"),
+                            secondary_bundle("Move Camera"),
                             (value_bundle(), Text::new("WSAD")),
                         ],
-                    )
+                    ),
+                    (
+                        row_node.clone(),
+                        children![
+                            secondary_bundle("Show/Hide AABB"),
+                            (value_bundle(), Text::new("Q"),),
+                        ],
+                    ),
                 ],
             ),
         ],
@@ -199,4 +206,14 @@ fn move_camera(
         t.translation.y += y as f32 * 300. * time.delta_secs();
         t.scale = (t.scale + (zoom as f32) * 0.1).max(Vec3::splat(0.1));
     });
+}
+
+fn toggle_aabb_gizmo(
+    inputs: Res<ButtonInput<KeyCode>>,
+    mut gizmo_config_store: ResMut<GizmoConfigStore>,
+) {
+    if inputs.just_pressed(KeyCode::KeyQ) {
+        let aabb_gizmo = gizmo_config_store.config_mut::<AabbGizmoConfigGroup>().1;
+        aabb_gizmo.draw_all = !aabb_gizmo.draw_all;
+    }
 }


### PR DESCRIPTION
While using this crate, I discovered that the AABBs for the spawners do not take the spawner's translation into account when calculating the AABBs.

My first commit adds a visualisation option to all examples to display the AABBs.
My second commit fixes this issue by subtracting the spawner's translation from the centre of the AABB and changing the initial values of min/max.


# before
<img width="1595" height="936" alt="image" src="https://github.com/user-attachments/assets/04490038-36fe-4618-852d-0deebf01f0bb" />


# after
<img width="1598" height="938" alt="image" src="https://github.com/user-attachments/assets/5fd1423f-de75-4d78-b331-b846b0f31a02" />
